### PR TITLE
Update nvms.py

### DIFF
--- a/nvms.py
+++ b/nvms.py
@@ -12,7 +12,7 @@ from urllib3 import HTTPConnectionPool
 import time
 import re
 
-rgxip = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+rgxip = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
 class bcolors:
     HEADER = '\033[34m'


### PR DESCRIPTION
nvms.py:14: SyntaxWarning: invalid escape sequence '\d'
  rgxip = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")